### PR TITLE
patch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,21 +145,22 @@ Here are a list of available options
 
  Use: -b  or --build-directory    Help: -h-b  or --help-build-directory
  Use: -bs or --boot-strap         Help: -h-bs or --help-boot-strap
- Use: -n  or --no-delete          Help: -h-n  or --help-no-delete
  Use: -i  or --icu                Help: -h-i  or --help-icu
- Use: -m  or --master             Help: -h-m  or --help-master
  Use: -lm or --libtorrent-master  Help: -h-lm or --help-libtorrent-master
  Use: -lt or --libtorrent-tag     Help: -h-lt or --help-libtorrent-tag
+ Use: -m  or --master             Help: -h-m  or --help-master
+ Use: -n  or --no-delete          Help: -h-n  or --help-no-delete
+ Use: -o  or --optimize           Help: -h-o  or --help-optimize
+ Use: -p  or --proxy              Help: -h-p  or --help-proxy
  Use: -qm or --qbittorrent-master Help: -h-qm or --help-qbittorrent-master
  Use: -qt or --qbittorrent-tag    Help: -h-qt or --help-qbittorrent-tag
- Use: -p  or --proxy              Help: -h-p  or --help-proxy
 
 Module specific help - flags are used with the modules listed here.
 
 Use: all or module-name          Usage: ~/qbittorrent-nox-static.sh all -i
 
  all         - Install all modules
- install     - optional Install the ~/qbittorrent-build/completed/qbittorrent-nox binary
+ install     - optional Install the ~/qb-build/completed/qbittorrent-nox binary
  bison       - required Build bison
  gawk        - required Build gawk
  glibc       - required Build libc locally to statically link nss

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See here for binaries I have built and how to install them - [Downloads](https:/
 
 ## Debian or Ubuntu platforms
 
-`glibc` - This script creates a fully static `qbittorrent-nox` binary using [libc](https://www.gnu.org/software/libc/).
+The script creates a fully static `qbittorrent-nox` binary using [libc](https://www.gnu.org/software/libc/).
 
 The final result will show this when using `ldd`
 
@@ -43,7 +43,7 @@ not a dynamic executable
 
 ## Alpine Linux platform
 
-`musl` - This script creates a fully static `qbittorrent-nox` binary using [musl](https://wiki.musl-libc.org/).
+The script creates a fully static `qbittorrent-nox` binary using [musl](https://wiki.musl-libc.org/).
 
 The final result will show this when using `ldd`
 
@@ -116,7 +116,7 @@ docker run -it -v $HOME/qb-build:/root alpine:latest /bin/ash -c 'apk update && 
 
 **Note:** Please see the flag summary section below to see what options you can pass and how to use them
 
-You can modify the installation command by editing this platform
+You can modify the installation command by editing this part of the docker command.
 
 ```bash
 bash -s all
@@ -133,17 +133,18 @@ bash -s all -i -lm
 Once the script has successfully configured the platform you can execute the help argument to see how it works and what options you have available to you.
 
 ```bash
-~/qbittorrent-nox-static.sh
+~/qbittorrent-nox-static.sh -h
 ```
 
 ### Flags and arguments summarised
 
-Please use this feature to get help with a script option.
+Please use this feature to get help with a script option. Here is what you will see.
 
 ```bash
 Here are a list of available options
 
  Use: -b  or --build-directory    Help: -h-b  or --help-build-directory
+ Use: -d  or --debug              Help: -h-d  or --help-debug
  Use: -bs or --boot-strap         Help: -h-bs or --help-boot-strap
  Use: -i  or --icu                Help: -h-i  or --help-icu
  Use: -lm or --libtorrent-master  Help: -h-lm or --help-libtorrent-master
@@ -152,15 +153,16 @@ Here are a list of available options
  Use: -n  or --no-delete          Help: -h-n  or --help-no-delete
  Use: -o  or --optimize           Help: -h-o  or --help-optimize
  Use: -p  or --proxy              Help: -h-p  or --help-proxy
+ Use: -pr or --patch-repo         Help: -h-pr or --help-patch-repo
  Use: -qm or --qbittorrent-master Help: -h-qm or --help-qbittorrent-master
  Use: -qt or --qbittorrent-tag    Help: -h-qt or --help-qbittorrent-tag
 
 Module specific help - flags are used with the modules listed here.
 
-Use: all or module-name          Usage: ~/qbittorrent-nox-static.sh all -i
+Use: all or module-name          Usage: ~/docker/qbittorrent-nox-static.sh all -i
 
  all         - Install all modules
- install     - optional Install the ~/qb-build/completed/qbittorrent-nox binary
+ install     - optional Install the ~/docker/qb-build/completed/qbittorrent-nox binary
  bison       - required Build bison
  gawk        - required Build gawk
  glibc       - required Build libc locally to statically link nss
@@ -172,6 +174,7 @@ Use: all or module-name          Usage: ~/qbittorrent-nox-static.sh all -i
  qttools     - required Build qttools locally
  libtorrent  - required Build libtorrent locally with b2
  qbittorrent - required Build qbitorrent locally
+
 ```
 
 ### Build - default profile

--- a/qbittorrent-nox-static.sh
+++ b/qbittorrent-nox-static.sh
@@ -104,7 +104,7 @@ set_default_values() {
 	qb_working_dir="$(printf "%s" "$(pwd <(dirname "${0}"))")" # Get the full path to the scripts location to use with setting some path related variables.
 	qb_working_dir_short="${qb_working_dir/$HOME/\~}"          # echo the working dir but replace the $HOME path with ~
 	#
-	qb_install_dir="${qb_working_dir}/qbuild"         # install relative to the script location.
+	qb_install_dir="${qb_working_dir}/qb-build"       # install relative to the script location.
 	qb_install_dir_short="${qb_install_dir/$HOME/\~}" # echo the install dir but replace the $HOME path with ~
 }
 #####################################################################################################################################################
@@ -467,47 +467,55 @@ apply_patches() {
 	#
 	[[ "$libtorrent_github_tag" =~ ^(libtorrent-1_1_[0-9]{1,2}|RC_1_1) ]] && lt_patch_github_tag="RC_1_1"
 	[[ "$libtorrent_github_tag" =~ ^(libtorrent-1_2_[0-9]{1,2}|RC_1_2|v1.2\.[0-9]{1,2})$ ]] && lt_patch_github_tag="RC_1_2"
-	[[ "$libtorrent_github_tag" =~ ^(RC_2_0|v2\.[0-9](\.[0-9]{1,2})?)$ ]] && lt_patch_github_tag="RC_2_0"
+	[[ "$libtorrent_github_tag" =~ ^(RC_2_0|v2\.0(\.[0-9]{1,2})?)$ ]] && lt_patch_github_tag="RC_2_0"
+	[[ "$libtorrent_github_tag" =~ ^(RC_2_1|v2\.1(\.[0-9]{1,2})?)$ ]] && lt_patch_github_tag="RC_2_1"
 	#
 	[[ "${qbittorrent_github_tag/release-/}" =~ (4.2.[0-9]{1,2}) ]] && qb_patch_github_tag="420"
 	[[ "${qbittorrent_github_tag/release-/}" =~ (4.3.[0-9]{1,2}) ]] && qb_patch_github_tag="430"
+	[[ "${qbittorrent_github_tag/release-/}" =~ (4.4.[0-9]{1,2}) ]] && qb_patch_github_tag="440"
+	[[ "${qbittorrent_github_tag/release-/}" =~ (4.5.[0-9]{1,2}) ]] && qb_patch_github_tag="450"
 	#
-	[[ "${patch_app_name}" = libtorrent && ! -d "$qb_install_dir/patches/${lt_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${lt_patch_github_tag}"
-	[[ "${patch_app_name}" = qbittorrent && ! -d "$qb_install_dir/patches/${qb_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${qb_patch_github_tag}"
-	#
-	patches_url="https://raw.githubusercontent.com/userdocs/filehosting/master/patches"
-	#
-	if [[ "${patch_app_name}" = libtorrent ]]; then
-		if [[ -f "$qb_install_dir/patches/${lt_patch_github_tag}/patch" ]]; then
-			echo -e "${cr} Using existing patch file${cend}"
-			echo
-		else
-			if curl_test "${patches_url}/${lt_patch_github_tag}/patch" -o "$qb_install_dir/patches/${lt_patch_github_tag}/patch"; then
-				echo -e "${cr} Using downloaded patch file${cend}"
-				echo
-			fi
-		fi
-		[[ -f "$qb_install_dir/patches/${lt_patch_github_tag}/patch" ]] && patch -p1 < "$qb_install_dir/patches/${lt_patch_github_tag}/patch"
+	if [[ "${patch_app_name}" == 'bootstrap' ]]; then
+		mkdir -p "$qb_install_dir/patches/${lt_patch_github_tag}"
+		mkdir -p "$qb_install_dir/patches/${qb_patch_github_tag}"
+	else
+		[[ "${patch_app_name}" = libtorrent && ! -d "$qb_install_dir/patches/${lt_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${lt_patch_github_tag}"
+		[[ "${patch_app_name}" = qbittorrent && ! -d "$qb_install_dir/patches/${qb_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${qb_patch_github_tag}"
 		#
-		# Jamfile patches
-		if curl_test "${patches_url}/${lt_patch_github_tag}/Jamfile" -o "$qb_install_dir/libtorrent/bindings/python/Jamfile"; then
-			true
-		else
-			curl "https://raw.githubusercontent.com/arvidn/libtorrent/${lt_patch_github_tag}/Jamfile" -o "${qb_install_dir}/libtorrent/Jamfile"
-		fi
-	fi
-	#
-	if [[ "${patch_app_name}" = qbittorrent ]]; then
-		if [[ -f "$qb_install_dir/patches/${qb_patch_github_tag}/patch" ]]; then
-			echo -e "${cr} Using existing patch file${cend}"
-			echo
-		else
-			if curl_test "${patches_url}/${qb_patch_github_tag}/patch" -o "$qb_install_dir/patches/${qb_patch_github_tag}/patch"; then
-				echo -e "${cr} Using downloaded patch file${cend}"
+		patches_url="https://raw.githubusercontent.com/userdocs/filehostsdgsging/master/patches"
+		#
+		if [[ "${patch_app_name}" = 'libtorrent' ]]; then
+			if [[ -f "$qb_install_dir/patches/${lt_patch_github_tag}/patch" ]]; then
+				echo -e "${cr} Using existing patch file${cend}"
 				echo
+			else
+				if curl_test "${patches_url}/${lt_patch_github_tag}/patch" -o "$qb_install_dir/patches/${lt_patch_github_tag}/patch"; then
+					echo -e "${cr} Using downloaded patch file${cend}"
+					echo
+				fi
+			fi
+			[[ -f "$qb_install_dir/patches/${lt_patch_github_tag}/patch" ]] && patch -p1 < "$qb_install_dir/patches/${lt_patch_github_tag}/patch"
+			#
+			# Jamfile patches
+			if curl_test "${patches_url}/${lt_patch_github_tag}/Jamfile" -o "$qb_install_dir/libtorrent/bindings/python/Jamfile"; then
+				true
+			else
+				curl "https://raw.githubusercontent.com/arvidn/libtorrent/${lt_patch_github_tag}/Jamfile" -o "${qb_install_dir}/libtorrent/Jamfile"
 			fi
 		fi
-		[[ -f "$qb_install_dir/patches/${qb_patch_github_tag}/patch" ]] && patch -p1 < "$qb_install_dir/patches/${qb_patch_github_tag}/patch"
+		#
+		if [[ "${patch_app_name}" = 'qbittorrent' ]]; then
+			if [[ -f "$qb_install_dir/patches/${qb_patch_github_tag}/patch" ]]; then
+				echo -e "${cr} Using existing patch file${cend}"
+				echo
+			else
+				if curl_test "${patches_url}/${qb_patch_github_tag}/patch" -o "$qb_install_dir/patches/${qb_patch_github_tag}/patch"; then
+					echo -e "${cr} Using downloaded patch file${cend}"
+					echo
+				fi
+			fi
+			[[ -f "$qb_install_dir/patches/${qb_patch_github_tag}/patch" ]] && patch -p1 < "$qb_install_dir/patches/${qb_patch_github_tag}/patch"
+		fi
 	fi
 }
 #####################################################################################################################################################
@@ -663,16 +671,15 @@ set_module_urls # see functions
 while (("${#}")); do
 	case "${1}" in
 		-bs | --boot-strap)
-			mkdir -p "$qb_install_dir/patches/RC_1_2"
-			mkdir -p "$qb_install_dir/patches/430"
+			apply_patches bootstrap
 			echo
 			echo -e " ${cly}Using the defaults, these directories have been created:${cend}"
 			echo
-			echo -e " ${clc}$qb_install_dir_short/patches/RC_1_2${cend}"
+			echo -e " ${clc}$qb_install_dir_short/patches/${lt_patch_github_tag}${cend}"
 			echo
-			echo -e " ${clc}$qb_install_dir_short/patches/430${cend}"
+			echo -e " ${clc}$qb_install_dir_short/patches/${qb_patch_github_tag}${cend}"
 			echo
-			echo -e " If a patch file is found in these directories it will be applied to the relevant app"
+			echo -e " If a patch file is found in these directories it will be applied to the relevant module with a matching tag."
 			echo
 			exit
 			;;

--- a/qbittorrent-nox-static.sh
+++ b/qbittorrent-nox-static.sh
@@ -74,6 +74,9 @@ fi
 set_default_values() {
 	DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" # For docker deploys to not get prompted to set the timezone.
 	#
+	# In this repo the structure needs to be like this /patches/RC_1_2/patch and/or /patches/430/patch and you patch file will be automatically fetched and loadded for those matching tags.
+	patches_url="" # Provide a git url in this format - https://raw.githubusercontent.com/username/repo/master/patches"
+	#
 	libtorrent_version='1.2' # Set this here so it is easy to see and change
 	#
 	qt_version='5.15' # Set this here so it is easy to see and change
@@ -206,6 +209,18 @@ while (("${#}")); do
 		-o | --optimize)
 			optimize="-march=native"
 			shift
+			;;
+		-h-o | --help-optimize)
+			echo
+			echo -e "${tb}${tu}Here is the help description for this flag:${cend}"
+			echo
+			echo -e " ${cly}Warning, using this flag will mean your static build is limited to a matching CPU${cend}"
+			echo
+			echo -e " Example: ${clb}-o${cend}"
+			echo
+			echo -e " Additonal flags used: ${clc}-march=native${cend}"
+			echo
+			exit 1
 			;;
 		-h-p | --help-proxy)
 			echo
@@ -482,8 +497,6 @@ apply_patches() {
 		[[ "${patch_app_name}" = libtorrent && ! -d "$qb_install_dir/patches/${lt_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${lt_patch_github_tag}"
 		[[ "${patch_app_name}" = qbittorrent && ! -d "$qb_install_dir/patches/${qb_patch_github_tag}" ]] && mkdir -p "$qb_install_dir/patches/${qb_patch_github_tag}"
 		#
-		patches_url="https://raw.githubusercontent.com/userdocs/filehostsdgsging/master/patches"
-		#
 		if [[ "${patch_app_name}" = 'libtorrent' ]]; then
 			if [[ -f "$qb_install_dir/patches/${lt_patch_github_tag}/patch" ]]; then
 				echo -e "${cr} Using existing patch file${cend}"
@@ -726,14 +739,15 @@ while (("${#}")); do
 			echo
 			echo -e " ${cg}Use:${cend} ${clb}-b${cend}  ${td}or${cend} ${clb}--build-directory${cend}    ${cy}Help:${cend} ${clb}-h-b${cend}  ${td}or${cend} ${clb}--help-build-directory${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-bs${cend} ${td}or${cend} ${clb}--boot-strap${cend}         ${cy}Help:${cend} ${clb}-h-bs${cend} ${td}or${cend} ${clb}--help-boot-strap${cend}"
-			echo -e " ${cg}Use:${cend} ${clb}-n${cend}  ${td}or${cend} ${clb}--no-delete${cend}          ${cy}Help:${cend} ${clb}-h-n${cend}  ${td}or${cend} ${clb}--help-no-delete${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-i${cend}  ${td}or${cend} ${clb}--icu${cend}                ${cy}Help:${cend} ${clb}-h-i${cend}  ${td}or${cend} ${clb}--help-icu${cend}"
-			echo -e " ${cg}Use:${cend} ${clb}-m${cend}  ${td}or${cend} ${clb}--master${cend}             ${cy}Help:${cend} ${clb}-h-m${cend}  ${td}or${cend} ${clb}--help-master${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-lm${cend} ${td}or${cend} ${clb}--libtorrent-master${cend}  ${cy}Help:${cend} ${clb}-h-lm${cend} ${td}or${cend} ${clb}--help-libtorrent-master${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-lt${cend} ${td}or${cend} ${clb}--libtorrent-tag${cend}     ${cy}Help:${cend} ${clb}-h-lt${cend} ${td}or${cend} ${clb}--help-libtorrent-tag${cend}"
+			echo -e " ${cg}Use:${cend} ${clb}-m${cend}  ${td}or${cend} ${clb}--master${cend}             ${cy}Help:${cend} ${clb}-h-m${cend}  ${td}or${cend} ${clb}--help-master${cend}"
+			echo -e " ${cg}Use:${cend} ${clb}-n${cend}  ${td}or${cend} ${clb}--no-delete${cend}          ${cy}Help:${cend} ${clb}-h-n${cend}  ${td}or${cend} ${clb}--help-no-delete${cend}"
+			echo -e " ${cg}Use:${cend} ${clb}-o${cend}  ${td}or${cend} ${clb}--optimize${cend}           ${cy}Help:${cend} ${clb}-h-o${cend}  ${td}or${cend} ${clb}--help-optimize${cend}"
+			echo -e " ${cg}Use:${cend} ${clb}-p${cend}  ${td}or${cend} ${clb}--proxy${cend}              ${cy}Help:${cend} ${clb}-h-p${cend}  ${td}or${cend} ${clb}--help-proxy${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-qm${cend} ${td}or${cend} ${clb}--qbittorrent-master${cend} ${cy}Help:${cend} ${clb}-h-qm${cend} ${td}or${cend} ${clb}--help-qbittorrent-master${cend}"
 			echo -e " ${cg}Use:${cend} ${clb}-qt${cend} ${td}or${cend} ${clb}--qbittorrent-tag${cend}    ${cy}Help:${cend} ${clb}-h-qt${cend} ${td}or${cend} ${clb}--help-qbittorrent-tag${cend}"
-			echo -e " ${cg}Use:${cend} ${clb}-p${cend}  ${td}or${cend} ${clb}--proxy${cend}              ${cy}Help:${cend} ${clb}-h-p${cend}  ${td}or${cend} ${clb}--help-proxy${cend}"
 			echo
 			echo -e "${tb}${tu}Module specific help - flags are used with the modules listed here.${cend}"
 			echo

--- a/qbittorrent-nox-static.sh
+++ b/qbittorrent-nox-static.sh
@@ -794,11 +794,13 @@ while (("${#}")); do
 			echo
 			echo -e "${tb}${tu}Here is the help description for this flag:${cend}"
 			echo
-			echo -e " Creates this dir: ${cc}${qb_install_dir_short}/patches${cend}"
+			echo -e " Creates dirs in this structure: ${cc}${qb_install_dir_short}/patches/TAG/patch${cend}"
 			echo
-			echo -e " Add you patches here in the format module name, for example."
+			echo -e " Add you patches there, for example."
 			echo
-			echo -e " ${cc}${qb_install_dir_short}/patches${cend}"
+			echo -e " ${cc}${qb_install_dir_short}/patches/RC_1_2/patch${cend}"
+			echo
+			echo -e " ${cc}${qb_install_dir_short}/patches/430/patch${cend}"
 			echo
 			exit 1
 			;;


### PR DESCRIPTION
use patch files one of two ways.

`./scriptname -bs` to create the default dirs and place your patches in those dirs as a file named `patch`.

```bash
 Using the defaults, these directories have been created:

 ~/qbuild/patches/RC_1_2

 ~/qbuild/patches/430 # 420 for 4.2.1, 4.2.5 and so on.

 If a patch file is found in these directories it will be applied to the relevant app and matching tag
```

Or have them stored in a github repo. 

Using this example https://raw.githubusercontent.com/userdocs/filehosting/master/patches/430/patch

```
/patches/RC_1_2/patch
/patches/RC_2_0/patch
/patches/420/patch
/patches/430/patch
```

This line will control the default repo. https://github.com/userdocs/qbittorrent-nox-static/blob/patch/qbittorrent-nox-static.sh#L478

These file will be pulled automatically and used unless the file already exists in the relevant tag.