### PR TITLE
Ability to fetch tags for older versions of qt

### DIFF
--- a/qbittorrent-nox-static.sh
+++ b/qbittorrent-nox-static.sh
@@ -386,8 +386,10 @@ set_module_urls() {
 	boost_github_url="https://github.com/boostorg/boost.git"
 	#
 	qtbase_github_tag="$(grep -Eom1 "v${qt_version}.([0-9]{1,2})" <(curl "https://github.com/qt/qtbase/releases"))"
+	while [[ -z "${qtbase_github_tag}" && "${qtbase_page}" -le 3 ]]; do ((qtbase_page++)); qtbase_github_tag="$(grep -Eom1 "v${qt_version}.([0-9]{1,2})" <(curl "https://api.github.com/repos/qt/qtbase/tags?per_page=100&page=${qtbase_page}"))"; done
 	qtbase_github_url="https://github.com/qt/qtbase.git"
 	qttools_github_tag="$(grep -Eom1 "v${qt_version}.([0-9]{1,2})" <(curl "https://github.com/qt/qttools/releases"))"
+	while [[ -z "${qttools_github_tag}" && "${qttools_page}" -le 3 ]]; do ((qttools_page++)); qttools_github_tag="$(grep -Eom1 "v${qt_version}.([0-9]{1,2})" <(curl "https://api.github.com/repos/qt/qttools/tags?per_page=100&page=${qttools_page}"))"; done
 	qttools_github_url="https://github.com/qt/qttools.git"
 	#
 	libtorrent_github_url="https://github.com/arvidn/libtorrent.git"


### PR DESCRIPTION
I encountered an error where qtbase_github_tag and qttools_github_tag were all empty strings when I tried to build qbittorrent 4.1.9 with an older version of qt. (5.13 to be precise)
I changed the source URL for qt to use GitHub API which can specify per_page and page arguments which enables us to get all the existing tags. Since you could specify qt version in set_default_values(), older qt tags should be supported, and using the API is by far the only way that came to my mind. Also, I've read PR #10, so please feel free to just close this PR if you have a better implementation or don't think switching to the API is worth it as qbittorrent will probably work just fine with newer versions of qt.