### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/amd64-icu-patch.yml
+++ b/.github/workflows/amd64-icu-patch.yml
@@ -26,7 +26,7 @@ jobs:
       # - run: bash qbittorrent-nox-static.sh qbittorrent
       - run: bash qbittorrent-nox-static.sh qbittorrent -pr jerry048/Patch
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/amd64-icu.yml
+++ b/.github/workflows/amd64-icu.yml
@@ -26,7 +26,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh qbittorrent
       # - run: bash qbittorrent-nox-static.sh qbittorrent -pr userdocs/qbittorrent-nox-static
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/amd64-patch.yml
+++ b/.github/workflows/amd64-patch.yml
@@ -26,7 +26,7 @@ jobs:
       # - run: bash qbittorrent-nox-static.sh qbittorrent
       - run: bash qbittorrent-nox-static.sh qbittorrent -pr jerry048/Patch
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -26,7 +26,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh qbittorrent
       # - run: bash qbittorrent-nox-static.sh qbittorrent -pr userdocs/qbittorrent-nox-static
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/arm64-icu-patch.yml
+++ b/.github/workflows/arm64-icu-patch.yml
@@ -13,7 +13,7 @@ jobs:
                   # args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -i"
                   args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -i -pr userdocs/qbittorrent-nox-static"
             - name: Archive code coverage results
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v2.2.3
               with:
                   name: qbittorrent-nox
                   path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/arm64-icu.yml
+++ b/.github/workflows/arm64-icu.yml
@@ -13,7 +13,7 @@ jobs:
           args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -i"
           # args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -i -pr userdocs/qbittorrent-nox-static"
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/arm64-patch.yml
+++ b/.github/workflows/arm64-patch.yml
@@ -13,7 +13,7 @@ jobs:
           # args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all"
           args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -pr userdocs/qbittorrent-nox-static"
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -13,7 +13,7 @@ jobs:
           args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all"
           # args: /bin/ash -c "apk update && apk add bash && bash qbittorrent-nox-static.sh all -pr userdocs/qbittorrent-nox-static"
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: qbittorrent-nox
           path: qb-build/completed/qbittorrent-nox

--- a/.github/workflows/sh-checker.yml
+++ b/.github/workflows/sh-checker.yml
@@ -6,7 +6,7 @@ jobs:
   sh-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
       - name: Run the sh-checker
         uses: luizm/action-sh-checker@v0.1.13
         env:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release [v2.2.3](https://github.com/actions/upload-artifact/releases/tag/v2.2.3) on 2021-04-06T21:07:45Z
