### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/amd64-icu-patch.yml
+++ b/.github/workflows/amd64-icu-patch.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: apk add bash
         shell: ash {0}
       - run: bash qbittorrent-nox-static.sh

--- a/.github/workflows/amd64-icu.yml
+++ b/.github/workflows/amd64-icu.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: apk add bash
         shell: ash {0}
       - run: bash qbittorrent-nox-static.sh

--- a/.github/workflows/amd64-patch.yml
+++ b/.github/workflows/amd64-patch.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: apk add bash
         shell: ash {0}
       - run: bash qbittorrent-nox-static.sh

--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: apk add bash
         shell: ash {0}
       - run: bash qbittorrent-nox-static.sh

--- a/.github/workflows/arm64-icu-patch.yml
+++ b/.github/workflows/arm64-icu-patch.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             - name: arm64v8 image
               uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64-icu.yml
+++ b/.github/workflows/arm64-icu.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: arm64v8 image
         uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64-patch.yml
+++ b/.github/workflows/arm64-patch.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: arm64v8 image
         uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: arm64v8 image
         uses: docker://arm64v8/alpine

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.SECRET_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
