### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/sh-checker.yml
+++ b/.github/workflows/sh-checker.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Run the sh-checker
-        uses: luizm/action-sh-checker@v0.2.2
+        uses: luizm/action-sh-checker@v0.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHELLCHECK_OPTS: -e SC2034,SC1091 # It is possible to exclude some shellcheck warnings.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[luizm/action-sh-checker](https://github.com/luizm/action-sh-checker)** published a new release [v0.3.0](https://github.com/luizm/action-sh-checker/releases/tag/v0.3.0) on 2021-06-09T21:05:09Z
