### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/matrix_multi_build_and_release.yml
+++ b/.github/workflows/matrix_multi_build_and_release.yml
@@ -92,7 +92,7 @@ jobs:
         run: mv -f "${{ env.build_dir }}/completed/qbittorrent-nox" "${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox"
 
       - name: "Create release - tag - assets"
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1.8.10
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: "${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox"

--- a/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
+++ b/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
@@ -95,7 +95,7 @@ jobs:
         run: mv -f "${{ env.build_dir }}/completed/qbittorrent-nox" "${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox"
 
       - name: "Create release - tag - assets"
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1.8.10
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: "${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release [v1.8.10](https://github.com/ncipollo/release-action/releases/tag/v1.8.10) on 2021-10-03T23:55:47Z
