### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/debian_based_CI.yml
+++ b/.github/workflows/debian_based_CI.yml
@@ -49,7 +49,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
         TZ: Europe/London
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - run: bash qbittorrent-nox-static.sh -bs-a ${{ matrix.build_tool_flag }}
       - run: bash qbittorrent-nox-static.sh bison

--- a/.github/workflows/matrix_multi_build_and_release.yml
+++ b/.github/workflows/matrix_multi_build_and_release.yml
@@ -38,7 +38,7 @@ jobs:
       name: "${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}libtorrent-v${{ matrix.libtorrent_version }}"
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - name: Host - update
         run: sudo apt-get update
@@ -111,7 +111,7 @@ jobs:
         run: docker exec -w /root/${{ env.build_dir }}/completed multiarch mv -f qbittorrent-nox ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox
 
       - name: Host- Create release - tag - assets
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1.8.10
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: ${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox

--- a/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
+++ b/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
@@ -41,7 +41,7 @@ jobs:
       name: "${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}libtorrent-v${{ matrix.libtorrent_version }}"
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - name: Host - update
         run: sudo apt-get update
@@ -114,7 +114,7 @@ jobs:
         run: docker exec -w /root/${{ env.build_dir }}/completed multiarch mv -f qbittorrent-nox ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox
 
       - name: Host- Create release - tag - assets
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1.8.10
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: ${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox

--- a/.github/workflows/multi_aarch64_artifacts.yml
+++ b/.github/workflows/multi_aarch64_artifacts.yml
@@ -36,7 +36,7 @@ jobs:
       qbt_cross_name: ${{ matrix.arch_type }}
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - run: apk add bash
         shell: ash {0}

--- a/.github/workflows/multi_armv7_artifacts.yml
+++ b/.github/workflows/multi_armv7_artifacts.yml
@@ -36,7 +36,7 @@ jobs:
       qbt_cross_name: ${{ matrix.arch_type }}
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - run: apk add bash
         shell: ash {0}

--- a/.github/workflows/multi_x86_64_artifacts.yml
+++ b/.github/workflows/multi_x86_64_artifacts.yml
@@ -36,7 +36,7 @@ jobs:
       qbt_cross_name: ${{ matrix.arch_type }}
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
 
       - run: apk add bash
         shell: ash {0}

--- a/.github/workflows/qt6_RC_2_0_icu_amd64.yml
+++ b/.github/workflows/qt6_RC_2_0_icu_amd64.yml
@@ -15,7 +15,7 @@ jobs:
       qbt_qt_version: "6.1"
       libtorrent_version: "2.0"
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
       - run: apk add bash
         shell: ash {0}
 

--- a/.github/workflows/sh-checker.yml
+++ b/.github/workflows/sh-checker.yml
@@ -6,7 +6,7 @@ jobs:
   sh-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
       - name: Run the sh-checker
         uses: luizm/action-sh-checker@v0.3.0
         env:

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.SECRET_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release [v1.8.10](https://github.com/ncipollo/release-action/releases/tag/v1.8.10) on 2021-10-03T23:55:47Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.4.0](https://github.com/actions/checkout/releases/tag/v2.4.0) on 2021-11-02T17:48:06Z
