### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/matrix_multi_build_and_release.yml
+++ b/.github/workflows/matrix_multi_build_and_release.yml
@@ -111,7 +111,7 @@ jobs:
         run: docker exec -w /root/${{ env.build_dir }}/completed multiarch mv -f qbittorrent-nox ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox
 
       - name: Host- Create release - tag - assets
-        uses: ncipollo/release-action@v1.8.10
+        uses: ncipollo/release-action@v1.9.0
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: ${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox

--- a/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
+++ b/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
@@ -114,7 +114,7 @@ jobs:
         run: docker exec -w /root/${{ env.build_dir }}/completed multiarch mv -f qbittorrent-nox ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox
 
       - name: Host- Create release - tag - assets
-        uses: ncipollo/release-action@v1.8.10
+        uses: ncipollo/release-action@v1.9.0
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: ${{ env.build_dir }}/completed/${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.icu_matrix_name }}qbittorrent-nox


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release [v1.9.0](https://github.com/ncipollo/release-action/releases/tag/v1.9.0) on 2021-11-26T22:01:13Z
