### PR TITLE
Disable `gtest_zlib` build

### DIFF
--- a/qbittorrent-nox-static.sh
+++ b/qbittorrent-nox-static.sh
@@ -2413,6 +2413,7 @@ _zlib() {
 			-D CMAKE_PREFIX_PATH="${qbt_install_dir}" \
 			-D BUILD_SHARED_LIBS=OFF \
 			-D ZLIB_COMPAT=ON \
+			-D WITH_GTEST=OFF \
 			-D CMAKE_INSTALL_PREFIX="${qbt_install_dir}" |& _tee -a "${qbt_install_dir}/logs/${app_name}.log"
 		cmake --build build |& _tee -a "${qbt_install_dir}/logs/${app_name}.log"
 		_post_command build


### PR DESCRIPTION
This circumvents the issue I encountered while building the binary on apple silicon (#172).