### PR TITLE
Update build help libtorrent flag

### DIFF
--- a/docs/src/content/docs/build-help.mdx
+++ b/docs/src/content/docs/build-help.mdx
@@ -24,7 +24,7 @@ You can export these before you run the script to set them. There is not specifi
 
 | Build variable                  | Default if unset                    | Options                            | example usage                                            |
 | ------------------------------- | ----------------------------------- | ---------------------------------- | -------------------------------------------------------- |
-| `libtorrent_version`            | `2.0`                               | `1.2` `2.0`                        | `export libtorrent_version=2.0`                          |
+| `qbt_libtorrent_version`            | `2.0`                               | `1.2` `2.0`                        | `export qbt_libtorrent_version=2.0`                          |
 | `qbt_qt_version`                | `6.3`                               | `5.12` `5.15` `6.3` `6.3.1`        | `export qbt_qt_version=6.3`                              |
 | `qbt_build_tool`                | `qmake`                             | `cmake`                            | `export qbt_build_tool=cmake`                            |
 | `qbt_cross_name`                | empty = `unset` (default to OS gcc) | `x86_64` `aarch64` `armv7` `armhf` | `export qbt_cross_name=aarch64`                          |


### PR DESCRIPTION
After exporting `libtorrent_version=1.2` and building, I noticed the script still built qbittorrent-nox with libtorrent 2.0, because the flag needs `qbt_` added.