### PR TITLE
Add openssl4 compat patch for qtbase 6.11.1

### DIFF
--- a/patches/qtbase/6.11.1/url
+++ b/patches/qtbase/6.11.1/url
@@ -1,0 +1,1 @@
+https://www.linuxfromscratch.org/patches/blfs/svn/qt-everywhere-src-6.11.1-openssl4_fix-1.patch


### PR DESCRIPTION
  ## Summary                        
  - Add OpenSSL 4 compatibility for qtbase 6.11.1 used in the static qBittorrent nox build.
  - Pins the patch to `patches/qtbase/6.11.1/url` so it is applied during the Qt build step.

  ## Background
  Qt 6.11.1 was released against OpenSSL 3.x. OpenSSL 4 introduces stricter const-correctness on several
  `ASN1_*` / `X509*` APIs, which makes the OpenSSL TLS plugin in qtbase fail to compile against the newer
   OpenSSL release. This breaks the static build whenever the toolchain is bumped to OpenSSL 4.

  ## What the patch does
  Upstream source: [Linux From Scratch `qt-everywhere-src-6.11.1-openssl4_fix-1.patch`](https://www.linuxfromscratch.org/patches/blfs/svn/qt-everywhere-src-6.11.1-openssl4_fix-1.patch), derived from the
  pending upstream Qt change at https://codereview.qt-project.org/c/qt/qtbase/+/725635 